### PR TITLE
make the jar directly executable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,31 @@
         </executions>
             </plugin>
 
+            
+        <plugin>
+          <groupId>org.skife.maven</groupId>
+          <artifactId>really-executable-jar-maven-plugin</artifactId>
+          <version>1.1.0</version>
+          <configuration>
+            <!-- value of flags will be interpolated into the java invocation -->
+            <!-- as "java $flags -jar ..." -->
+            <flags>-Xmx2G</flags>
+            
+            <!-- (optional) name for binary executable, if not set will just -->
+            <!-- make the regular jar artifact executable -->
+            <programFile>simmer</programFile>
+          </configuration>
+          
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>really-executable-jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
     </plugins>
   </build>
 


### PR DESCRIPTION
Rather then have the dependency on ruby, etc, this patch makes the generated jar actually chmod +x executable (and still a valid jar!).
