### PR TITLE
UDPInput: Only look at as many bytes of the packet as we actually received

### DIFF
--- a/src/main/scala/com/stripe/simmer/UDPInput.scala
+++ b/src/main/scala/com/stripe/simmer/UDPInput.scala
@@ -12,7 +12,7 @@ class UDPInput(port : Int) extends Input {
     while(true) {
       val packet = new DatagramPacket(buf, buf.length)
       sock.receive(packet)
-      val str = new String(packet.getData)
+      val str = new String(packet.getData, 0, packet.getLength)
       val columns = str.split("\t")
       if(columns.size > 1)
         simmer.update(columns(0), columns(1))


### PR DESCRIPTION
Without this, the String constructor just scans until it finds a NULL byte, meaning it will scan until the end of the longest packet we've ever received, adding gibberish onto the end of our message.
