### PR TITLE
Exponential Moving Average

### DIFF
--- a/src/main/scala/com/stripe/simmer/Aggregators.scala
+++ b/src/main/scala/com/stripe/simmer/Aggregators.scala
@@ -136,7 +136,6 @@ class Decay(halflife : Int) extends KryoAggregator[DecayedValue] with NumericAgg
 
 class ExponentialMovingAverage(percent: Int) extends DoubleAggregator {
   val alpha = percent / 100.0
-  println(alpha)
   val monoid = new Monoid[Double] {
     val zero = 0.0
     def plus(left: Double, right: Double) =  alpha * left + (1-alpha) * right

--- a/src/main/scala/com/stripe/simmer/Aggregators.scala
+++ b/src/main/scala/com/stripe/simmer/Aggregators.scala
@@ -135,6 +135,8 @@ class Decay(halflife : Int) extends KryoAggregator[DecayedValue] with NumericAgg
 }
 
 class ExponentialMovingAverage(percent: Int) extends DoubleAggregator {
+  require(percent >= 0)
+  require(percent <= 100)
   val alpha = percent / 100.0
   val monoid = new Monoid[Double] {
     val zero = 0.0

--- a/src/main/scala/com/stripe/simmer/Aggregators.scala
+++ b/src/main/scala/com/stripe/simmer/Aggregators.scala
@@ -15,6 +15,7 @@ object AlgebirdAggregators extends Registrar {
 	register("pct", 50){new Percentile(_)}
 	register("fh", 10){new HashingTrick(_)}
 	register("dcy", 86400){new Decay(_)}
+  register("ema", 90){new ExponentialMovingAverage(_)}
 	registerRecursive("top", 10){(k,inner) => new HeavyHitters(k,inner)}
 	registerRecursive("bot", 10){(k,inner) => new HeavyHitters(k,inner,-1.0)}
 }
@@ -131,6 +132,15 @@ class Decay(halflife : Int) extends KryoAggregator[DecayedValue] with NumericAgg
 	}
 
 	def present(out : DecayedValue) = presentNumeric(out).toString
+}
+
+class ExponentialMovingAverage(percent: Int) extends DoubleAggregator {
+  val alpha = percent / 100.0
+  println(alpha)
+  val monoid = new Monoid[Double] {
+    val zero = 0.0
+    def plus(left: Double, right: Double) =  alpha * left + (1-alpha) * right
+  }
 }
 
 class HeavyHitters[A](k : Int, inner : Aggregator[A], order : Double = 1.0) extends BufferableAggregator[SketchMap[String, A]] {


### PR DESCRIPTION
The parameter is the percent of the new value you want to keep:  `average  = percent * new + (1-percent) * old`. I was going to make the input be something like `ema0.5:x   1`, but it would take some work to parse a `Double`.

Example input:

```
ema50:x 1
ema50:x 2
ema50:x 3
ema50:x 4
ema50:x 5
ema50:x 6
ema50:x 7
ema50:x 6
ema50:x 5
ema50:x 4
ema50:x 3
ema50:x 2
ema50:x 1
```

Example output:

```
ema50:x 1.968994140625  1.968994140625
```

Here's how I'd calculate this in "normal" scala. Note that the first value has to go into the fold's init parameter.

```
scala> val x = Seq[Double](2,3,4,5,6,7,6,5,4,3,2,1)
x: Seq[Double] = List(2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0)

scala> x.foldLeft(1.0)(_*.5 + _*.5)
res1: Double = 1.968994140625
```
